### PR TITLE
Fix go `command` doc

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -27,7 +27,7 @@ If you want to actually launch a `go` application, consider setting the `command
 services:
   myservice:
     type: go
-    command: run /app/my-server.go
+    command: go run /app/my-server.go
 ```
 
 ## Using SSL


### PR DESCRIPTION
When running a `go` web service, the `command:` argument needs to have the full go command:

```bash
go run /app/my-service.go
```