### PR TITLE
Add support for go 1.18 and 1.19

### DIFF
--- a/services/go/builder.js
+++ b/services/go/builder.js
@@ -8,7 +8,7 @@ module.exports = {
   name: 'go',
   config: {
     version: '1.17',
-    supported: ['1.17', '1.16', '1.15', '1.14', '1.13'],
+    supported: ['1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13'],
     patchesSupported: true,
     legacy: ['1.12', '1.11', '1.10', '1.9', '1.8'],
     command: 'tail -f /dev/null',


### PR DESCRIPTION
This simply adds support for the latest two versions of go.